### PR TITLE
Fixed an issue where event handlers with no return value would block …

### DIFF
--- a/source/kmwbase.js
+++ b/source/kmwbase.js
@@ -213,7 +213,8 @@ var __BUILD__ = 300;
       var func=util.events[event][i],result=false;
       try { result=func(params); }
       catch(strExcept) { result=false; }//don't know whether to use true or false here      
-      if(!result) { util.currentEvents.pop(); return false; }
+      if(result === false) {return false;}
+	  else {util.currentEvents.pop();}
     }    
     util.currentEvents.pop();
     return true;

--- a/source/kmwbase.js
+++ b/source/kmwbase.js
@@ -213,8 +213,7 @@ var __BUILD__ = 300;
       var func=util.events[event][i],result=false;
       try { result=func(params); }
       catch(strExcept) { result=false; }//don't know whether to use true or false here      
-      if(result === false) {return false;}
-	  else {util.currentEvents.pop();}
+      if(result === false) {util.currentEvents.pop(); return false;}
     }    
     util.currentEvents.pop();
     return true;


### PR DESCRIPTION
…any further event handlers from executing.

This was caused due to the return value being undefined, and !undefined evaluates to true.
Fixing that alone would have caused the event stack to never get smaller however, so an else was added to the if statement.

I opted to fix it this way when I realized that changing all of the calls to addEventHandler in the toggleUI to include a return statement just wasn't going to be a feasible solution.